### PR TITLE
Suppress the PHP 8+ deprecation message that pops when APP_DEBUG=true

### DIFF
--- a/src/Configuration/Symfony.php
+++ b/src/Configuration/Symfony.php
@@ -54,6 +54,7 @@ final class Symfony implements PropertiesInterface
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->cas->offsetExists($offset);
@@ -64,6 +65,7 @@ final class Symfony implements PropertiesInterface
      *
      * @return array<string, mixed>|mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->cas->offsetGet($offset);


### PR DESCRIPTION
This PR

* [x] Suppress the PHP 8+ deprecation message that pops when APP_DEBUG=true

For PHP <8 projects, the attribute `#[\ReturnTypeWillChange]` will be ignored as it starts with a `#`. 

Adding this attribute allows using the bundle with PHP 8+ (without that annoying deprecation message) without breaking the compatibility with lower PHP versions.