### PR TITLE
Update demo casserver URL

### DIFF
--- a/Resources/config/packages/dev/cas_bundle.yaml
+++ b/Resources/config/packages/dev/cas_bundle.yaml
@@ -1,5 +1,5 @@
 cas:
-    base_url: https://heroku-cas-server.herokuapp.com/cas
+    base_url: https://casserver.herokuapp.com/cas
     protocol:
         login:
             path: /login

--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -9,7 +9,7 @@ Hereunder an example of configuration for CAS Bundle.
 
 .. code:: yaml
 
-   base_url: https://heroku-cas-server.herokuapp.com/cas
+   base_url: https://casserver.herokuapp.com/cas
    protocol:
      login:
        path: /login


### PR DESCRIPTION
This PR

- [x] Updates casserver URL in config files to match the Apereo official public demo cas server

The updated URL is already mentioned in the documentation (see https://github.com/ecphp/cas-bundle/blob/master/docs/pages/installation.rst?plain=1#L109), but the default/sample config files contained a different URL.

Follows #. Related to #. Fixes #.
