### PR TITLE
Fix link in documentation

### DIFF
--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -4,4 +4,4 @@ Contributing
 See the file `CONTRIBUTING.md`_ but feel free to contribute to this
 project by sending Github pull requests.
 
-.. _CONTRIBUTING.md: .github/CONTRIBUTING.md
+.. _CONTRIBUTING.md: https://github.com/ecphp/cas-bundle/blob/master/.github/CONTRIBUTING.md


### PR DESCRIPTION
This PR

- [x] fixes link to the CONTRIBUTING.md page in documentation

Follows #. Related to #. Fixes #.
