### PR TITLE
chore: maintenance - compatibility with Symfony 7 - minor fixes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 use flake github:loophp/nix-auto-changelog
-use flake github:loophp/nix-shell#env-php81 --impure
+use flake github:loophp/nix-shell#env-php83 --impure

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019-2023, European Union.
+Copyright (c) 2019-2024, European Union.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,11 @@
     ],
     "require": {
         "php": ">= 8.1",
-        "ext-filter": "*",
-        "ext-simplexml": "*",
         "ecphp/cas-lib": "^3",
         "loophp/psr-http-message-bridge-bundle": "^1.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
-        "symfony/framework-bundle": "^6.1 || ^7.0"
+        "psr/http-message": "^1.0 || ^2.0",
+        "symfony/framework-bundle": "^6.4 || ^7"
     },
     "require-dev": {
         "ext-pcov": "*",
@@ -31,12 +29,12 @@
         "nyholm/psr7": "^1.8",
         "phpspec/phpspec": "^7",
         "phpstan/phpstan-symfony": "^1.1",
-        "symfony/cache": "^6.1 || ^7.0",
-        "symfony/dependency-injection": "^6.1 || ^7.0",
-        "symfony/http-client": "^6.1 || ^7.0",
-        "symfony/routing": "^6.1 || ^7.0",
-        "symfony/security-bundle": "^6.1 || ^7.0",
-        "veewee/xml": "^2.6"
+        "symfony/cache": "^6.4 || ^7",
+        "symfony/dependency-injection": "^6.4 || ^7",
+        "symfony/http-client": "^6.4 || ^7",
+        "symfony/routing": "^6.4 || ^7",
+        "symfony/security-bundle": "^6.4 || ^7",
+        "veewee/xml": "^2.6 || ^3"
     },
     "suggest": {
         "loophp/unaltered-psr-http-message-bridge-bundle": "A drop-in replacement for symfony/psr-http-message-bridge, that does not alter query parameters.",

--- a/src/Security/CasAuthenticator.php
+++ b/src/Security/CasAuthenticator.php
@@ -30,6 +30,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Throwable;
 
+use function sprintf;
+
 final class CasAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface
 {
     public function __construct(

--- a/src/Security/Core/User/CasUserProvider.php
+++ b/src/Security/Core/User/CasUserProvider.php
@@ -21,6 +21,8 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Throwable;
 
+use function sprintf;
+
 final class CasUserProvider implements CasUserProviderInterface
 {
     public function __construct(
@@ -28,7 +30,7 @@ final class CasUserProvider implements CasUserProviderInterface
         private readonly HttpMessageFactoryInterface $httpMessageFactory
     ) {}
 
-    public function loadUserByIdentifier($identifier): UserInterface
+    public function loadUserByIdentifier(string $identifier): UserInterface
     {
         throw new UnsupportedUserException('Unsupported operation.');
     }

--- a/src/Security/Core/User/CasUserProviderInterface.php
+++ b/src/Security/Core/User/CasUserProviderInterface.php
@@ -14,6 +14,9 @@ namespace EcPhp\CasBundle\Security\Core\User;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
+/**
+ * @template-extends UserProviderInterface<CasUserInterface>
+ */
 interface CasUserProviderInterface extends UserProviderInterface
 {
     public function loadUserByResponse(Response $response): CasUserInterface;


### PR DESCRIPTION
This PR:

- Fix #98
- Update the Symfony 6 and 7 dependencies constraints. The minimum Symfony version bound is now 6.4 and the upper bound is Symfony 7. 
- Will need https://github.com/symfony/recipes-contrib/pull/1687