### PR TITLE
Do not redirect ajax requests on auth success

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019-2024, European Union.
+Copyright (c) 2019-2025, European Union.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/Security/CasAuthenticator.php
+++ b/src/Security/CasAuthenticator.php
@@ -80,8 +80,13 @@ final class CasAuthenticator extends AbstractAuthenticator implements Authentica
         return new RedirectResponse($request->getUri());
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): Response
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
+        // let the request through if it is an ajax request
+        if (true === $request->isXmlHttpRequest()) {
+            return null;
+        }
+
         $request->query->remove('ticket');
         $request->query->remove('renew');
 


### PR DESCRIPTION
Redirecting ajax requests on successful authentication triggers a ticket re-validation, which fails because the ticket is already consumed. 

- [x]
- [ ]
- [ ]

Follows #. Related to #. Fixes #.
